### PR TITLE
Added option wrapContent

### DIFF
--- a/js/jquery.trackpad-scroll-emulator.js
+++ b/js/jquery.trackpad-scroll-emulator.js
@@ -60,7 +60,9 @@
       $scrollbarEl = $el.find('.tse-scrollbar');
       $dragHandleEl = $el.find('.drag-handle');
 
-      $contentEl.wrap('<div class="tse-scroll-content" />');
+      if (options.wrapContent) {
+        $contentEl.wrap('<div class="tse-scroll-content" />');
+      }
       $scrollContentEl = $el.find('.tse-scroll-content');
 
       resizeScrollContent();
@@ -294,7 +296,8 @@
  
   $.fn[pluginName].defaults = {
     onInit: function() {},
-    onDestroy: function() {}
+    onDestroy: function() {},
+    wrapContent: true
   };
  
 })(jQuery);


### PR DESCRIPTION
Added plugin option wrapContent (defaults to true for API compatibility). When false, we do not wrap `.tse-content` in `.tse-scroll-content` for when you can ensure that the DOM already has the desired structure.
