### PR TITLE
Trigger native scrolling support for mobile devices

### DIFF
--- a/css/trackpad-scroll-emulator.css
+++ b/css/trackpad-scroll-emulator.css
@@ -10,6 +10,7 @@
   width: 200px; /* Default value. Overwite this if you want. */
   height: 300px; /* Default value. Overwite this if you want. */
   overflow: hidden;
+  -webkit-overflow-scrolling: touch; /* Trigger native scrolling for mobile, if not supported, plugin is used. */
   }
   .tse-scrollable .tse-scroll-content {
     overflow: hidden;

--- a/jquery.trackpad-scroll-emulator.js
+++ b/jquery.trackpad-scroll-emulator.js
@@ -49,6 +49,12 @@
      * Initialize plugin
      */
     function init() {
+      if(hasOverflowScrolling()) {
+        $el.css('overflow', 'auto');
+
+        return;
+      }
+
       if ($el.hasClass('horizontal')){
         scrollDirection = 'horiz';
         scrollOffsetAttr = 'scrollLeft';
@@ -268,6 +274,47 @@
       if (options[hookName] !== undefined) {
         options[hookName].call(el);
       }
+    }
+
+    /**
+     * Check for mobile Overflow scrolling support
+     * Source: https://gist.github.com/hay/4032527
+     */
+    function hasOverflowScrolling() {
+        var prefixes = ['webkit', 'moz', 'o', 'ms'];
+        var div = document.createElement('div');
+        var body = document.getElementsByTagName('body')[0];
+        var hasIt = false;
+     
+        body.appendChild(div);
+     
+        for (var i = 0; i < prefixes.length; i++) {
+            var prefix = prefixes[i];
+            div.style[prefix + 'OverflowScrolling'] = 'touch';
+        }
+     
+        // And the non-prefixed property
+        div.style.overflowScrolling = 'touch';
+     
+        // Now check the properties
+        var computedStyle = window.getComputedStyle(div);
+     
+        // First non-prefixed
+        hasIt = !!computedStyle.overflowScrolling;
+     
+        // Now prefixed...
+        for (var i = 0; i < prefixes.length; i++) {
+            var prefix = prefixes[i];
+            if (!!computedStyle[prefix + 'OverflowScrolling']) {
+                hasIt = true;
+                break;
+            }
+        }
+     
+        // Cleanup old div elements
+        div.parentNode.removeChild(div);
+     
+        return hasIt;
     }
 
     init();


### PR DESCRIPTION
Resolve issue #3 
Use native scrollbar/scrolling for mobile devices (especially iOS safari).
Will not change anything for Chrome Android as it already supports native scrolling when overflow: auto is detected.
